### PR TITLE
Update docs

### DIFF
--- a/docs/tool-runner.md
+++ b/docs/tool-runner.md
@@ -60,7 +60,7 @@ invoke(repomatic, args=['run', '--list'])
 | [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt)             | `2.16.2` | PyPI        | `[tool.pyproject-fmt]` in `pyproject.toml`                   |
 | [Ruff](https://github.com/astral-sh/ruff)                             | `0.15.5` | PyPI        | `ruff.toml`, `.ruff.toml`, `[tool.ruff]` in `pyproject.toml` |
 | [shfmt](https://github.com/mvdan/sh)                                  | `3.13.1` | Binary      | `.editorconfig`                                              |
-| [typos](https://github.com/crate-ci/typos)                            | `1.46.1` | Binary      | `[tool.typos]` in `pyproject.toml`                           |
+| [typos](https://github.com/crate-ci/typos)                            | `1.46.2` | Binary      | `[tool.typos]` in `pyproject.toml`                           |
 | [yamllint](https://github.com/adrienverge/yamllint)                   | `1.38.0` | PyPI        | `.yamllint.yaml`, `.yamllint.yml`, `.yamllint`               |
 | [zizmor](https://github.com/zizmorcore/zizmor)                        | `1.23.0` | PyPI        | `zizmor.yaml`                                                |
 
@@ -658,7 +658,7 @@ shfmt formats shell scripts in place. It has no `[tool.shfmt]` section: indentat
 
 ### [typos](https://github.com/crate-ci/typos)
 
-**Installed version:** `1.46.1`
+**Installed version:** `1.46.2`
 
 **Installation method:** Binary (downloaded from GitHub Releases)
 


### PR DESCRIPTION
### Description

Regenerates API documentation with [sphinx-apidoc](https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html), converts RST stubs to [MyST markdown](https://myst-parser.readthedocs.io/) if applicable, and runs the project's `docs_update.py` script if present. See the [`update-docs` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`b9d9be0d`](https://github.com/kdeldycke/repomatic/commit/b9d9be0d1ead10df789b7ab45ce9ca0c61c3b9f2) |
| **Job** | [`update-docs`](https://github.com/kdeldycke/repomatic/blob/b9d9be0d1ead10df789b7ab45ce9ca0c61c3b9f2/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/b9d9be0d1ead10df789b7ab45ce9ca0c61c3b9f2/.github/workflows/autofix.yaml) |
| **Run** | [#4686.1](https://github.com/kdeldycke/repomatic/actions/runs/26518564422) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.23.0.dev0`