### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -36,11 +36,11 @@ wheels = [
 
 [[package]]
 name = "aiohappyeyeballs"
-version = "2.6.1"
+version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/c6/61a2d7b7572279226bb2e7f61d7a19ca7c90da0329c93fa0d560cbf288d8/aiohappyeyeballs-2.6.2.tar.gz", hash = "sha256:e202810ee718bd01fc6ef49e8ea53d023d5cb6b581076d7925aa499fa55dbe64", size = 22591, upload-time = "2026-05-20T15:12:24.631Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/fc/a7bf5b6e4e617b45f90f2d9d2a68519c249c81dd4fc2658c7a2a61c4f4b7/aiohappyeyeballs-2.6.2-py3-none-any.whl", hash = "sha256:4708045e2d7a6c6bdf8aafa8ed39649eaf926a4543b54560659129e3365953c4", size = 15062, upload-time = "2026-05-20T15:12:23.328Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-05-20`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [aiohappyeyeballs](https://pypi.org/project/aiohappyeyeballs/) | [`2.6.1` → `2.6.2`](https://github.com/aio-libs/aiohappyeyeballs/compare/v2.6.1...v2.6.2) | 2026-05-20 |

### Release notes

<details>
<summary><code>aiohappyeyeballs</code></summary>

#### [`v2.6.2`](https://github.com/aio-libs/aiohappyeyeballs/releases/tag/v2.6.2)

## v2.6.2 (2026-05-20)

### Bug Fixes

- Clear error on empty addr_infos in start_connection ([#​222](https://redirect.github.com/aio-libs/aiohappyeyeballs/pull/222), [`55dd76a`](https://redirect.github.com/aio-libs/aiohappyeyeballs/commit/55dd76aee978ca47a38899b9caf69d058bf41fb3))

### Refactoring

- Optimize obtaining event-loop down to 1 line ([#​185](https://redirect.github.com/aio-libs/aiohappyeyeballs/pull/185), [`02a7029`](https://redirect.github.com/aio-libs/aiohappyeyeballs/commit/02a70296210125b45952c3221db0dfb76d8ea911))

### Testing

- Stop verify_no_lingering_tasks from leaking an event loop ([#​221](https://redirect.github.com/aio-libs/aiohappyeyeballs/pull/221), [`ce43beb`](https://redirect.github.com/aio-libs/aiohappyeyeballs/commit/ce43beb0242007dc57be6e2f4e3bf0b9f4f239d1))

---

**Detailed Changes**: [v2.6.1...v2.6.2](https://redirect.github.com/aio-libs/aiohappyeyeballs/compare/v2.6.1...v2.6.2)

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`45448774`](https://github.com/kdeldycke/repomatic/commit/454487748399307e412200e3d9a058e28c18cc9b) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/454487748399307e412200e3d9a058e28c18cc9b/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/454487748399307e412200e3d9a058e28c18cc9b/.github/workflows/autofix.yaml) |
| **Run** | [#4690.1](https://github.com/kdeldycke/repomatic/actions/runs/26521714358) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.23.0.dev0`