### PR TITLE
Fix changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@
 
 ## [`6.24.0` (2026-05-28)](https://github.com/kdeldycke/repomatic/compare/v6.23.0...v6.24.0)
 
+> [!NOTE]
+> `6.24.0` is available on [🐍 PyPI](https://pypi.org/project/repomatic/6.24.0/) and [🐙 GitHub](https://github.com/kdeldycke/repomatic/releases/tag/v6.24.0).
+
 - Split the package build into its own reusable `_release-build.yaml` lane (squash-merge guard, project metadata, and the signed `build-package` job), so the entry `release.yaml`'s `publish-pypi` job depends only on the freshly-built wheel and ships to PyPI right after the build instead of after the whole engine (binary compilation, VirusTotal scan) completes. `_release-engine.yaml` keeps the binary and release-finalization jobs and is gated on the build lane (`needs: build`) so its `create-release` and `sync-dev-release` jobs reuse the same run-scoped wheel (one build, one attestation, shared to both PyPI and the GitHub release). Downstream `release.yaml` is regenerated with three jobs (`build`, `publish-pypi`, `release`) by copying the canonical entry and rewriting each `uses:` to the pinned cross-repo ref; `publish-pypi`'s `package_built`, `release_commits_matrix`, and `release_notes_with_admonition` now come from the build lane.
 
 ## [`6.23.0` (2026-05-28)](https://github.com/kdeldycke/repomatic/compare/v6.22.0...v6.23.0)


### PR DESCRIPTION
### Description

Fixes changelog release dates and updates availability admonitions.

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`pypi-package-history`](https://kdeldycke.github.io/repomatic/configuration.html#pypi-package-history)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/changelog.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `schedule` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`d55a92b7`](https://github.com/kdeldycke/repomatic/commit/d55a92b7c5b83ae68e51ac3367521dc49362e53f) |
| **Job** | [`fix-changelog`](https://github.com/kdeldycke/repomatic/blob/d55a92b7c5b83ae68e51ac3367521dc49362e53f/.github/workflows/changelog.yaml) |
| **Workflow** | [`changelog.yaml`](https://github.com/kdeldycke/repomatic/blob/d55a92b7c5b83ae68e51ac3367521dc49362e53f/.github/workflows/changelog.yaml) |
| **Run** | [#4213.1](https://github.com/kdeldycke/repomatic/actions/runs/27260964781) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.24.1.dev0`