### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1940,14 +1940,14 @@ wheels = [
 
 [[package]]
 name = "sphinx-autodoc-typehints"
-version = "3.10.4"
+version = "3.10.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", marker = "python_full_version >= '3.14'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/aa/d676b736c126250e91fff6da35f14160eb85b3a5b75b076915b9f249a9f6/sphinx_autodoc_typehints-3.10.4.tar.gz", hash = "sha256:8fa06b4c92f4bd883928d9d38a7c676d94a05a170b7ee20084a1ad360d6b25ea", size = 79571, upload-time = "2026-05-31T16:08:19.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/88/f4698f838b8cc030f3df73cf529f96d7c9e6dd3e3ff40968b7fe4d86c748/sphinx_autodoc_typehints-3.10.5.tar.gz", hash = "sha256:a54dfab95a6b5e8601543d25474497e98ed59268ac0ab01b3daba9817cf9707e", size = 79721, upload-time = "2026-06-03T15:30:28.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/aa/cb936b1f0a741873d8841040d51e65a4888f99dd4a92f6122de8ad7c4c01/sphinx_autodoc_typehints-3.10.4-py3-none-any.whl", hash = "sha256:53f5273956497c96d44a149025a8f8eed2f3a0e8c36adec7fb09d8c02da2e11a", size = 40386, upload-time = "2026-05-31T16:08:17.606Z" },
+    { url = "https://files.pythonhosted.org/packages/41/9a/98ba24ca28b4a4afbb5066805838c7e1149b8de1e6f5e02774e0f39f13db/sphinx_autodoc_typehints-3.10.5-py3-none-any.whl", hash = "sha256:7155748080735731c892d09b5128bc4e5303795691ca8515ccf333b1efd8d964", size = 40433, upload-time = "2026-06-03T15:30:26.892Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-03`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | [`3.10.4` → `3.10.5`](https://github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.4...3.10.5) | 2026-06-03 |

### Release notes

<details>
<summary><code>sphinx-autodoc-typehints</code></summary>

#### [`3.10.5`](https://github.com/tox-dev/sphinx-autodoc-typehints/releases/tag/3.10.5)

<!-- Release notes generated using configuration in .github/release.yaml at main -->

## What's Changed
* process_signature: don't skip the first arg on bound instance methods by @​ilia-kats in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/705
* 🐛 fix(annotations): use class role for Ellipsis/NotImplementedType on 3.13+ by @​gaborbernat in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/707

## New Contributors
* @​ilia-kats made their first contribution in https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/pull/705

**Full Changelog**: https://redirect.github.com/tox-dev/sphinx-autodoc-typehints/compare/3.10.4...3.10.5

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`cb8f5a06`](https://github.com/kdeldycke/repomatic/commit/cb8f5a066ab9538a838db94594b6240f239a4784) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/cb8f5a066ab9538a838db94594b6240f239a4784/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/cb8f5a066ab9538a838db94594b6240f239a4784/.github/workflows/autofix.yaml) |
| **Run** | [#4724.1](https://github.com/kdeldycke/repomatic/actions/runs/27296210216) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.24.1.dev0`