### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2242,11 +2242,11 @@ wheels = [
 
 [[package]]
 name = "wcwidth"
-version = "0.7.0"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/44/c833e6b746ffb654e9abacf7ad6c2480a9c8c42e9637c1ae849964fb4dde/wcwidth-0.8.0.tar.gz", hash = "sha256:68a882ff6d14e3d14e0cae590b96a0551be64ce4905408112a8254434a1bdf69", size = 1305357, upload-time = "2026-06-05T21:19:35.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/17/c68b6cbcfeadbf420b3c3edaf8fda51335bc9c38732adb2d3ba8984dc607/wcwidth-0.8.0-py3-none-any.whl", hash = "sha256:8c75e6099cefd197c4bcc67a486f70b5dbc68f997c05f34a811d853910450d64", size = 324935, upload-time = "2026-06-05T21:19:33.999Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description

Runs `uv lock --upgrade` to update transitive dependencies to their latest allowed versions. See the [`sync-uv-lock` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.

### Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-06-06`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [wcwidth](https://pypi.org/project/wcwidth/) | [`0.7.0` → `0.8.0`](https://github.com/jquast/wcwidth/compare/0.7.0...0.8.0) | 2026-06-05 |

### Release notes

<details>
<summary><code>wcwidth</code></summary>

#### [`0.8.0`](https://github.com/jquast/wcwidth/releases/tag/0.8.0)

* **New** support for Variation Selector 15 Emojis as narrow, #​211.
* **New** argument, ``term_program`` for `wcstwidth()`_, `width()`_, `clip()`_, `wrap()`_, `ljust()`_, `rjust()`_, and `center()`_.  ``False`` disables corrections; ``True`` auto-detects by ``TERM_PROGRAM`` or ``TERM``; string values accept canonical names matching `list_term_programs()`_.  `wcstwidth()`_ defaults to ``True``; all other functions default to ``False``.
* **Improved** performance on Python 3.15 using standard library iter_graphemes() #​206.
* **Improved** memory usage and import time for Python 3.15 using lazy imports #​221.
* **Bugfix** Invisible_Stacker viramas now form conjuncts (Burmese, Khmer, etc.) and change some Virama width calculations to match `jacobsandlund/uucode`_ (ghostty) #​223.
* **Updated** graphemes width maximum now 2, matching Ghostty, foot, and Windows Terminal #​224.

**Full Changelog**: https://redirect.github.com/jquast/wcwidth/compare/0.7.0...0.8.0

</details>

### Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`uv-lock.sync`](https://kdeldycke.github.io/repomatic/configuration.html#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`5c931fff`](https://github.com/kdeldycke/repomatic/commit/5c931fff5b222a9242af0efc1950a7936baa0e2b) |
| **Job** | [`sync-uv-lock`](https://github.com/kdeldycke/repomatic/blob/5c931fff5b222a9242af0efc1950a7936baa0e2b/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/5c931fff5b222a9242af0efc1950a7936baa0e2b/.github/workflows/autofix.yaml) |
| **Run** | [#4765.1](https://github.com/kdeldycke/repomatic/actions/runs/27455549822) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.25.0.dev0`