### PR TITLE
Update docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,7 @@ workflow.ignore-paths = ["uv.lock"]
 
 | Option                                                        | Description                                                                                                               | Default                             |
 | :------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------ | :---------------------------------- |
+| [`abandoned-versions`](#abandoned-versions)                   | Versions documented in the changelog but never published.                                                                 | `[]`                                |
 | [`agents.location`](#agents-location)                         | Directory prefix for Claude Code agent files, relative to the repository root.                                            | `"./.claude/agents/"`               |
 | [`awesome-template.sync`](#awesome-template-sync)             | Whether awesome-template sync is enabled for this project.                                                                | `true`                              |
 | [`bumpversion.sync`](#bumpversion-sync)                       | Whether bumpversion config sync is enabled for this project.                                                              | `true`                              |
@@ -121,6 +122,26 @@ workflow.ignore-paths = ["uv.lock"]
 | [`workflow.paths`](#workflow-paths)                           | Per-workflow override of the `paths:` filter, keyed by filename.                                                          | {}                                  |
 | [`workflow.source-paths`](#workflow-source-paths)             | Source code directory names for workflow trigger `paths:` filters.                                                        | *(none)*                            |
 | [`workflow.sync`](#workflow-sync)                             | Whether workflow sync is enabled for this project.                                                                        | `true`                              |
+
+### `abandoned-versions`
+
+Versions documented in the changelog but never published.
+
+**Type:** `list[str]` | **Default:** `[]`
+
+A version reached only its `[changelog] Release vX.Y.Z` freeze and was then
+skipped per `CLAUDE.md` § Skip and move forward (botched build, broken
+artifact, bad metadata) without rewriting history. List those versions here
+so `lint-changelog` reports them as skipped (an info log line) instead of
+flagging them every run as `⚠ X.Y.Z: not found on PyPI`. Applies to both
+PyPI lookups and the git-tag fallback.
+
+**Example:**
+
+```toml
+[tool.repomatic]
+abandoned-versions = []
+```
 
 ### `agents.location`
 


### PR DESCRIPTION
### Description

Regenerates API documentation with [sphinx-apidoc](https://www.sphinx-doc.org/en/master/man/sphinx-apidoc.html), converts RST stubs to [MyST markdown](https://myst-parser.readthedocs.io/) if applicable, and runs the project's `docs_update.py` script if present. See the [`update-docs` job documentation](https://kdeldycke.github.io/repomatic/workflows.html#github-workflows-autofix-yaml-jobs) for details.


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

| Field | Value |
| :-- | :-- |
| **Trigger** | `push` |
| **Actor** | @kdeldycke |
| **Ref** | `main` |
| **Commit** | [`99de348f`](https://github.com/kdeldycke/repomatic/commit/99de348f94a604c9599114654f64ff4257434ae8) |
| **Job** | [`update-docs`](https://github.com/kdeldycke/repomatic/blob/99de348f94a604c9599114654f64ff4257434ae8/.github/workflows/autofix.yaml) |
| **Workflow** | [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/99de348f94a604c9599114654f64ff4257434ae8/.github/workflows/autofix.yaml) |
| **Run** | [#4768.1](https://github.com/kdeldycke/repomatic/actions/runs/27457558660) |

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `6.25.0.dev0`