### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tooling/tool_registry.py
+++ b/repomatic/tooling/tool_registry.py
@@ -1043,53 +1043,53 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "bf593f7955e3a437fb8056b255142b50872baa3e81371cda2c3fce9239af1890",
+        ): "fb1238183c5dcfe9bb48772922c2ab62fa54158bfdc78352fa2851f41a71fa5a",
         (
             LINUX,
             X86_64,
-        ): "013eb5158b9e53235dbbf31255cb3b776fb9338b32fa6ff4a44ee1ceed65ee63",
+        ): "511592536991d4b07179d063b93ff0c092ccedba556a4b1ea70d12d46ea0785a",
         (
             MACOS,
             AARCH64,
-        ): "7d8b51dec857ffa8aa35ce5eaa3a4476cd62bed013adc2896bf43cac0a67a79b",
+        ): "828bc29680765b656b6a354de01d9a7f9f5111e6af99b04cefe06d09c6d2dbda",
         (
             MACOS,
             X86_64,
-        ): "df2b50ee283634cdd6f7570b7da06bc3c9cd7ec0590ecbbaf986c7590bef3289",
+        ): "3d87fe407532d708650be535573b159293e5c0176b51f8065eb45cc6e6861f48",
         (
             WINDOWS,
             AARCH64,
-        ): "d6845ff075043300551d4ad74985814e4e4c56b49ffa87b3724ddf5055a2efe9",
+        ): "58707afd02cc8522324e8f83906f44c9a78ceb4953c01e86def94bcd47fed0f9",
         (
             WINDOWS,
             X86_64,
-        ): "f8474a0f9f457df176c10be3f0e82be890e8986ff2805d4a7f3c5a4cba5962ca",
+        ): "65125b8689718242c5e86aef43a9099e3313bec2c3fecb7a1bade02018b85acb",
     },
     "gh": {
         (
             LINUX,
             AARCH64,
-        ): "73ea440ecad9c9e284429997ee6f93577bc6f7bc6fba357ef62c53ad8fb641a5",
+        ): "cf689084f3a3618f7eae4a2420d335d74626d65f5e594b9828d125d69f800d86",
         (
             LINUX,
             X86_64,
-        ): "a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112",
+        ): "3b8ac6b30336802fc1a858d7c084e11cdf24ac1a761ca90b68022d7d729208de",
         (
             MACOS,
             AARCH64,
-        ): "a58b8fd77b417a38f47a0b54d1370c59b0fcdb324ccc9ca002b0998f7c4c999e",
+        ): "8cfb027cc5310675f2b830eac8f9865c1155a45ffcf9757f699fdd5a22046ca4",
         (
             MACOS,
             X86_64,
-        ): "63298c998cc2a924c9e254c6af6a1caad6ece281122687a91f079bc0a462700e",
+        ): "734c7bbd0bc56a3974500ee9aea74d60f0e5b89be09e92b9d9148939a3a1e0e6",
         (
             WINDOWS,
             AARCH64,
-        ): "3e2d4a166da4ee5020c592737b65eec0e724946d5d5b962f5fe59d99116dc4bf",
+        ): "79e53db4e50b5c9594890a1c4d9dc941f6d19f7c3ca6d1f50982eda624607b9b",
         (
             WINDOWS,
             X86_64,
-        ): "35d7fe05c4dd1411ffda1e73dfc7c6f44b75c936ca51fa6595c657fdc0350cec",
+        ): "c28c7b3b584967a05b74d9eaf7481bff24ddc34930bf2d6e442c148236561eb1",
     },
     "gitleaks": {
         (
@@ -1234,8 +1234,8 @@ the registry, and so `VERSIONS` can anchor the offline staleness test.
 
 VERSIONS: dict[str, str] = {
     "actionlint": "1.7.12",
-    "biome": "2.5.9",
-    "gh": "2.97.0",
+    "biome": "2.5.10",
+    "gh": "2.98.0",
     "gitleaks": "8.30.1",
     "labelmaker": "0.6.4",
     "lychee": "0.24.2",
@@ -1361,7 +1361,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         ),
         default_paths="json_files",
         display_name="Biome",
-        version="2.5.9",
+        version="2.5.10",
         source_url="https://github.com/biomejs/biome",
         tag_pattern=r"^@biomejs/biome@(?P<version>.+)$",
         config_docs_url="https://biomejs.dev/reference/configuration/",
@@ -1452,7 +1452,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "gh": ToolSpec(
         name="gh",
         display_name="GitHub CLI",
-        version="2.97.0",
+        version="2.98.0",
         source_url="https://github.com/cli/cli",
         cli_docs_url="https://cli.github.com/manual/",
         binary=BinarySpec(
@@ -1884,7 +1884,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "ruff": ToolSpec(
         name="ruff",
         display_name="Ruff",
-        version="0.16.3",
+        version="0.16.4",
         source_url="https://github.com/astral-sh/ruff",
         config_docs_url="https://docs.astral.sh/ruff/configuration/",
         cli_docs_url="https://docs.astral.sh/ruff/configuration/#command-line-interface",


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown `1 week`: releases after `2026-08-23` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.9` → `2.5.10` | 2026-08-21 (a week ago) |
| [gh](https://github.com/cli/cli) | `2.97.0` → `2.98.0` | 2026-08-20 (a week ago) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.3` → `0.16.4` | 2026-08-20 (a week ago) |

### Release notes

<details>
<summary><code>biome</code></summary>

#### [`@biomejs/biome@2.5.10`](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.10)

##### 2.5.10

###### Patch Changes

- [#​11403](https://redirect.github.com/biomejs/biome/pull/11403) [`8f7786f`](https://redirect.github.com/biomejs/biome/commit/8f7786ff62aef61cf75a91e1604cd380456a60f4) Thanks [@​Princesseuh](https://redirect.github.com/Princesseuh)! - Fixed Astro rejecting JavaScript comments between attributes.

  ```astro
  <div /* block comment */ class="something"></div>
  <Component /* c */ client:load />
  ```

- [#​11403](https://redirect.github.com/biomejs/biome/pull/11403) [`8f7786f`](https://redirect.github.com/biomejs/biome/commit/8f7786ff62aef61cf75a91e1604cd380456a60f4) Thanks [@​Princesseuh](https://redirect.github.com/Princesseuh)! - Fixed a bare `<` in Astro text being treated as the start of a tag, such as `<p>5 < 6 and 7 > 6</p>`. As in HTML, a `<` that cannot open a tag is text and needs no escaping.

- [#​11438](https://redirect.github.com/biomejs/biome/pull/11438) [`3133ffa`](https://redirect.github.com/biomejs/biome/commit/3133ffa9ae6beaa3c4464edac60de47d5c6f6426) Thanks [@​Princesseuh](https://redirect.github.com/Princesseuh)! - Fixed [#​8294](https://redirect.github.com/biomejs/biome/issues/8294): an Astro expression holding only a comment is no longer reported as a parse error, which also stopped the whole file from being formatted.

  ```astro
  <div>{/* a note */}</div>
  <div class={/* a note */}>x</div>
  ```

- [#​11403](https://redirect.github.com/biomejs/biome/pull/11403) [`8f7786f`](https://redirect.github.com/biomejs/biome/commit/8f7786ff62aef61cf75a91e1604cd380456a60f4) Thanks [@​Princesseuh](https://redirect.github.com/Princesseuh)! - Fixed [#​9165](https://redirect.github.com/biomejs/biome/issues/9165): an empty Astro expression such as `<div>{}</div>` no longer fails to parse. Astro renders `{}` as nothing.

... [Full release notes](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.10)

</details>

<details>
<summary><code>gh</code></summary>

#### [`v2.98.0`](https://github.com/cli/cli/releases/tag/v2.98.0)

##### Security
A security vulnerability has been identified, and fixed, that binds the local forwarded port to all available network interfaces by default.

Users of `gh codespace ports forward` are advised to update `gh` to version `v2.98.0` as soon as possible.

For more information see: https://redirect.github.com/cli/cli/security/advisories/GHSA-vfhh-p7hm-pxfh

##### Support worktrees in `pr checkout`

Users can now checkout a pull request into a git worktree by using the new `--worktree PATH` flag in `gh pr checkout`:

```shell
gh pr checkout 12 --worktree ../wt-feature
```

##### Add semantic search to `search issues`

The `gh search issues` command now supports semantic search for issues. Users can select the search type by passing the `--search-type` flag:

```shell
gh search issues --search-type semantic ...

gh search issues --search-type hybrid ...
```

For more information about semantic search see: ["Improved Search for github issues is now generally available"](https://github.blog/changelog/2026-04-02-improved-search-for-github-issues-is-now-generally-available/).

##### What's Changed

###### ✨ Features
* Add --worktree flag to gh pr checkout by @​tidy-dev in https://redirect.github.com/cli/cli/pull/13946
* Set GH_EXTENSION=1 when gh invokes an extension by @​williammartin in https://redirect.github.com/cli/cli/pull/14072
* Add --search-type flag for semantic and hybrid issue search by @​michaeljacholke in https://redirect.github.com/cli/cli/pull/14006

###### 🐛 Fixes
* Fix `RESTWithNext` error type, repairing `gh status` and attestation retries by @​williammartin in https://redirect.github.com/cli/cli/pull/13988
* Trim spaces when parsing X-Oauth-Scopes in `gh release create` by @​williammartin in https://redirect.github.com/cli/cli/pull/14065
* Fix project item-add output for non-TTY by @​zwick in https://redirect.github.com/cli/cli/pull/14056

###### 📚 Docs & Chores

... [Full release notes](https://github.com/cli/cli/releases/tag/v2.98.0)

</details>

<details>
<summary><code>ruff</code></summary>

#### [`0.16.4`](https://github.com/astral-sh/ruff/releases/tag/0.16.4)

##### Release Notes

Released on 2026-08-20.

###### Preview features

- \[`flake8-use-pathlib`\] Add autofix for `PTH116` ([#​26460](https://redirect.github.com/astral-sh/ruff/pull/26460))
- \[`refurb`\] Restrict `delete-full-slice` to lists (`FURB131`) ([#​27711](https://redirect.github.com/astral-sh/ruff/pull/27711))
- \[`refurb`\] Skip `FURB101` and `FURB103` when the `open` argument is a file descriptor ([#​27643](https://redirect.github.com/astral-sh/ruff/pull/27643))

###### Bug fixes

- Fix `InvalidInstruction` on Windows CPUs that do not support `POPCNT` ([#​27803](https://redirect.github.com/astral-sh/ruff/pull/27803))
- \[`pyflakes`\] Emit semantic syntax errors in string type definitions as `F722` ([#​27835](https://redirect.github.com/astral-sh/ruff/pull/27835))
- \[`pylint`\] Allow `os._exit` imports in `import-private-name` (`PLC2701`) ([#​27738](https://redirect.github.com/astral-sh/ruff/pull/27738))

###### Rule changes

- [syntax-errors] Align mixed t-string/bytes error message with CPython 3.14 ([#​27766](https://redirect.github.com/astral-sh/ruff/pull/27766))
- \[`ruff`\] Add `ctypes.LittleEndianStructure` and related types to existing exception (`RUF012`) ([#​27753](https://redirect.github.com/astral-sh/ruff/pull/27753))
- [syntax-errors] Detect duplicate keyword arguments ([#​17804](https://redirect.github.com/astral-sh/ruff/pull/17804))
- [syntax-errors] Detect parameters declared `nonlocal` ([#​27628](https://redirect.github.com/astral-sh/ruff/pull/27628))

###### Server

- Offer display-only fixes and mark safe fixes preferred ([#​27807](https://redirect.github.com/astral-sh/ruff/pull/27807))
- Support pull diagnostics for notebook cells ([#​27779](https://redirect.github.com/astral-sh/ruff/pull/27779))

###### Documentation

- Add default indicator to rules table ([#​27724](https://redirect.github.com/astral-sh/ruff/pull/27724))
- Fix broken link to Python docs ([#​27757](https://redirect.github.com/astral-sh/ruff/pull/27757))

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.16.4)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.10` | `2.5.11` | 2026-08-27 (3 days ago) | 2026-09-03 (in 4 days) |
| [nuitka](https://github.com/Nuitka/Nuitka) | `4.1.3` | `4.2` | 2026-08-27 (3 days ago) | 2026-09-03 (in 4 days) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.28.0` | `2.28.2` | 2026-08-28 (2 days ago) | 2026-09-04 (in 5 days) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.4` | `0.16.5` | 2026-08-27 (3 days ago) | 2026-09-03 (in 4 days) |
| [shfmt](https://github.com/mvdan/sh) | `3.13.1` | `3.14.0` | 2026-08-28 (2 days ago) | 2026-09-04 (in 5 days) |
| [typos](https://github.com/crate-ci/typos) | `1.49.0` | `1.50.0` | 2026-08-28 (2 days ago) | 2026-09-04 (in 5 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age)
- [`tool-versions.sync`](https://repomatic.net/configuration#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/self-maintenance.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://repomatic.net/workflows#sync-tool-versions-sync-tool-versions)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`ef4ae4ed`](https://github.com/kdeldycke/repomatic/commit/ef4ae4ed9ecf7ee1c10574c86659335f569598a8)
- **Job**: [`sync-tool-versions`](https://github.com/kdeldycke/repomatic/blob/ef4ae4ed9ecf7ee1c10574c86659335f569598a8/.github/workflows/self-maintenance.yaml)
- **Workflow**: [`self-maintenance.yaml`](https://github.com/kdeldycke/repomatic/blob/ef4ae4ed9ecf7ee1c10574c86659335f569598a8/.github/workflows/self-maintenance.yaml)
- **Run**: [#24.1](https://github.com/kdeldycke/repomatic/actions/runs/33307075242)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.15.0.dev0`
