### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1919,14 +1919,14 @@ wheels = [
 
 [[package]]
 name = "tomlrt"
-version = "2.2.3"
+version = "2.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ef/d7/35f81ebae33cf51ad7e30f4d232bde4584dd00860d9f3487bfd28dc83131/tomlrt-2.2.3.tar.gz", hash = "sha256:a0ab3834348b3f47859c1306ae282bcda7c780e8270455a4c0c2dbd4b424c089", size = 410753, upload-time = "2026-08-17T21:19:26.689Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/52/047f13baf6e7d66960d06233937564faba983cbd75826661ef65734a110c/tomlrt-2.2.4.tar.gz", hash = "sha256:3cb50c7bd858c6936242a3dc23fd432e9a298355f7619e078dc544d955b96f95", size = 413435, upload-time = "2026-08-23T12:03:48.679Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/9b/c45482961dcf250eaf6dc44735f01ce0abbab1d8537009c03bd24122a9a7/tomlrt-2.2.3-py3-none-any.whl", hash = "sha256:8b2ac46bee4186ea0e85f20cdd9a0f2ab432dcd65a2b06e416c872102787163e", size = 144771, upload-time = "2026-08-17T21:19:25.263Z" },
+    { url = "https://files.pythonhosted.org/packages/90/e2/49ece6f1d2c4b4f5f1651b2720b0d1bddff5afd87f02cb3d91aedbc791c4/tomlrt-2.2.4-py3-none-any.whl", hash = "sha256:d492f53324ebe6fc346a78a1cd90c0d306b8c804dabac198f9d679bf7d2e973f", size = 146134, upload-time = "2026-08-23T12:03:47.458Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-08-24`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [tomlrt](https://pypi.org/project/tomlrt/) | `2.2.3` → `2.2.4` | 2026-08-23 (a week ago) |

### Release notes

<details>
<summary><code>tomlrt</code></summary>

[Changelog](https://redirect.github.com/dimbleby/tomlrt/blob/main/CHANGELOG.md)

</details>

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `9.0.0` | 2026-09-05 (in 5 days) |

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click](https://pypi.org/project/click/) | `8.4.2` | `8.5.0` | 2026-08-26 (5 days ago) | 2026-09-02 (in 2 days) |
| [coverage](https://pypi.org/project/coverage/) | `7.15.4` | `7.16.0` | 2026-08-28 (3 days ago) | 2026-09-04 (in 4 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.6.0` | `13.7.0` | 2026-08-28 (3 days ago) | 2026-09-04 (in 4 days) |
| [imagesize](https://pypi.org/project/imagesize/) | `2.0.0` | `2.0.1` | 2026-08-24 (a week ago) | 2026-08-31 (just now) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.2` | `3.13.4` | 2026-08-24 (a week ago) | 2026-08-31 (just now) |
| [tomlrt](https://pypi.org/project/tomlrt/) | `2.2.4` | `2.2.6` | 2026-08-30 (a day ago) | 2026-09-06 (in 6 days) |
| [types-docutils](https://pypi.org/project/types-docutils/) | `0.22.3.20260724` | `0.23.0.20260827` | 2026-08-27 (4 days ago) | 2026-09-03 (in 3 days) |
| [wcwidth](https://pypi.org/project/wcwidth/) | `0.8.2` | `0.8.3` | 2026-08-28 (3 days ago) | 2026-09-04 (in 4 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`uv-lock.sync`](https://repomatic.net/configuration#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://repomatic.net/workflows#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`2a937668`](https://github.com/kdeldycke/repomatic/commit/2a937668a1f21cafce32bb0396aa2b814b427514)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/2a937668a1f21cafce32bb0396aa2b814b427514/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/2a937668a1f21cafce32bb0396aa2b814b427514/.github/workflows/autofix.yaml)
- **Run**: [#5473.1](https://github.com/kdeldycke/repomatic/actions/runs/33387476020)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.15.0.dev0`
