### PR TITLE
Sync `uv.lock`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -845,11 +845,11 @@ wheels = [
 
 [[package]]
 name = "imagesize"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/5e/513ff06670c84e7b9887c1fdf61b2d42b4f574a831f2f1d2222023049d8a/imagesize-2.0.1.tar.gz", hash = "sha256:b2ba6a4dea487a7ebcd53248d3476aca449d30db12a2dde5e0c5ca9624fd77e5", size = 1883774, upload-time = "2026-08-24T12:35:19.13Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
+    { url = "https://files.pythonhosted.org/packages/01/f9/575c8d760eae1fc99651b7cc5efd96ad5379ca4d6b53750b0fb4fe983f34/imagesize-2.0.1-py3-none-any.whl", hash = "sha256:ea0c9a0384df69ed86a943a15cde37d0360b82491b3910dc2215e202e62b5b02", size = 14794, upload-time = "2026-08-24T12:35:12.548Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cutoff: `2026-08-24`.

| Package | Change | Released |
| :-- | :-- | :-- |
| [imagesize](https://pypi.org/project/imagesize/) | [`2.0.0` → `2.0.1`](https://github.com/shibukawa/imagesize_py/compare/2.0.0...2.0.1) | 2026-08-24 (a week ago) |

### Release notes

<details>
<summary><code>imagesize</code></summary>

#### [`2.0.1`](https://github.com/shibukawa/imagesize_py/releases/tag/2.0.1)

- Optimize metadata parsing and HTTP range reads.
- Fix JPEG2000 box parsing.
- Accept single-quoted SVG dimensions.
- Return positive heights for top-down BMP images.
- Remove the upper Python version cap, migrate packaging to pyproject.toml,
  and add Python 3.15 CI coverage.
- Bump the package version to 2.0.1 and add recent feedback contributors to
  the README.

Related issues:
https://redirect.github.com/shibukawa/imagesize_py/issues/64
https://redirect.github.com/shibukawa/imagesize_py/issues/83
https://redirect.github.com/shibukawa/imagesize_py/issues/84

Related pull requests:
https://redirect.github.com/shibukawa/imagesize_py/pull/86
https://redirect.github.com/shibukawa/imagesize_py/pull/87
https://redirect.github.com/shibukawa/imagesize_py/pull/88
https://redirect.github.com/shibukawa/imagesize_py/pull/89
https://redirect.github.com/shibukawa/imagesize_py/pull/90
https://redirect.github.com/shibukawa/imagesize_py/pull/91
https://redirect.github.com/shibukawa/imagesize_py/pull/92

</details>

## ❄️ Cooldown bypasses

Packages pulled in ahead of the cooldown by an [`exclude-newer-package`](https://docs.astral.sh/uv/reference/settings/#exclude-newer-package) freeze. Each entry is cleared from `pyproject.toml` automatically once its held version ages past the `exclude-newer` cutoff.

| Package | Held at | Held until |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `9.0.0` | 2026-09-05 (in 5 days) |

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`exclude-newer`](https://docs.astral.sh/uv/reference/settings/#exclude-newer) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [click](https://pypi.org/project/click/) | `8.4.2` | `8.5.0` | 2026-08-26 (5 days ago) | 2026-09-02 (in 2 days) |
| [coverage](https://pypi.org/project/coverage/) | `7.15.4` | `7.16.0` | 2026-08-28 (3 days ago) | 2026-09-04 (in 4 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.6.0` | `13.7.0` | 2026-08-28 (3 days ago) | 2026-09-04 (in 4 days) |
| [sphinx-autodoc-typehints](https://pypi.org/project/sphinx-autodoc-typehints/) | `3.13.2` | `3.13.4` | 2026-08-24 (a week ago) | 2026-08-31 (just now) |
| [tomlrt](https://pypi.org/project/tomlrt/) | `2.2.4` | `2.2.6` | 2026-08-30 (a day ago) | 2026-09-06 (in 6 days) |
| [types-docutils](https://pypi.org/project/types-docutils/) | `0.22.3.20260724` | `0.23.0.20260827` | 2026-08-27 (4 days ago) | 2026-09-03 (in 3 days) |
| [wcwidth](https://pypi.org/project/wcwidth/) | `0.8.2` | `0.8.3` | 2026-08-28 (3 days ago) | 2026-09-04 (in 4 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`uv-lock.sync`](https://repomatic.net/configuration#uv-lock-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-uv-lock`](https://repomatic.net/workflows#sync-uv-lock-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`ca26a7bb`](https://github.com/kdeldycke/repomatic/commit/ca26a7bb0565001064398c6d0790bdd51e01f44f)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/ca26a7bb0565001064398c6d0790bdd51e01f44f/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/ca26a7bb0565001064398c6d0790bdd51e01f44f/.github/workflows/autofix.yaml)
- **Run**: [#5475.1](https://github.com/kdeldycke/repomatic/actions/runs/33393443502)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.15.0.dev0`
