### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tooling/tool_registry.py
+++ b/repomatic/tooling/tool_registry.py
@@ -1855,7 +1855,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "pyproject-fmt": ToolSpec(
         name="pyproject-fmt",
         default_paths="pyproject_files",
-        version="2.28.0",
+        version="2.28.1",
         source_url="https://github.com/tox-dev/pyproject-fmt",
         config_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
         cli_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown `1 week`: releases after `2026-08-27` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.28.0` → `2.28.1` | 2026-08-24 (a week ago) |

### Release notes

<details>
<summary><code>pyproject-fmt</code></summary>

#### [`v2.28.1`](https://github.com/tox-dev/pyproject-fmt/releases/tag/v2.28.1)

<!-- Release notes generated using configuration in .github/release.yaml at v2.28.1 -->

##### What's Changed
* 🔧 chore: batch dependency updates weekly on Tuesday by @​gaborbernat in https://redirect.github.com/tox-dev/pyproject-fmt/pull/362

**Full Changelog**: https://redirect.github.com/tox-dev/pyproject-fmt/compare/v2.28.0...v2.28.1

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.10` | `2.5.12` | 2026-09-03 (just now) | 2026-09-10 (in a week) |
| [gh](https://github.com/cli/cli) | `2.98.0` | `2.99.0` | 2026-09-01 (2 days ago) | 2026-09-08 (in 5 days) |
| [nuitka](https://github.com/Nuitka/Nuitka) | `4.1.3` | `4.2` | 2026-08-27 (a week ago) | 2026-09-03 (just now) |
| [oxipng](https://github.com/shssoichiro/oxipng) | `10.2.0` | `10.2.1` | 2026-09-02 (a day ago) | 2026-09-09 (in 6 days) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.28.1` | `2.29.3` | 2026-09-01 (2 days ago) | 2026-09-08 (in 5 days) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.4` | `0.16.5` | 2026-08-27 (a week ago) | 2026-09-03 (just now) |
| [shfmt](https://github.com/mvdan/sh) | `3.13.1` | `3.14.0` | 2026-08-28 (6 days ago) | 2026-09-04 (in a day) |
| [typos](https://github.com/crate-ci/typos) | `1.49.0` | `1.50.1` | 2026-09-01 (2 days ago) | 2026-09-08 (in 5 days) |
| [zizmor](https://github.com/zizmorcore/zizmor) | `1.29.0` | `1.30.0` | 2026-08-30 (4 days ago) | 2026-09-06 (in 3 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age)
- [`tool-versions.sync`](https://repomatic.net/configuration#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/self-maintenance.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://repomatic.net/workflows#sync-tool-versions-sync-tool-versions)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`43a19ab1`](https://github.com/kdeldycke/repomatic/commit/43a19ab1af142d2f931293ca312fbb625dc8454c)
- **Job**: [`sync-tool-versions`](https://github.com/kdeldycke/repomatic/blob/43a19ab1af142d2f931293ca312fbb625dc8454c/.github/workflows/self-maintenance.yaml)
- **Workflow**: [`self-maintenance.yaml`](https://github.com/kdeldycke/repomatic/blob/43a19ab1af142d2f931293ca312fbb625dc8454c/.github/workflows/self-maintenance.yaml)
- **Run**: [#28.1](https://github.com/kdeldycke/repomatic/actions/runs/33742385358)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.15.0.dev0`
