### PR TITLE
Sync workflow pins

### DIFF
--- a/.github/workflows/_release-build.yaml
+++ b/.github/workflows/_release-build.yaml
@@ -210,7 +210,7 @@ jobs:
         env:
           COMMIT: ${{ matrix.commit }}
         run: >
-          uvx --no-progress 'click-extra==8.9.1'
+          uvx --no-progress 'click-extra==9.0.0'
           prebake field git_tag_sha "${COMMIT}"
       - name: Build package
         run: uv --no-progress build

--- a/.github/workflows/_release-engine.yaml
+++ b/.github/workflows/_release-engine.yaml
@@ -249,7 +249,7 @@ jobs:
           uv --no-progress sync --frozen ${flags}
       - name: Pre-bake build metadata
         if: contains(matrix.current_version, '.dev')
-        run: uvx --no-progress 'click-extra==8.9.1' prebake all
+        run: uvx --no-progress 'click-extra==9.0.0' prebake all
       - name: Build binary
         id: build-binary
         continue-on-error: true

--- a/.github/workflows/debug.yaml
+++ b/.github/workflows/debug.yaml
@@ -143,4 +143,4 @@ jobs:
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.4"
-      - run: uvx --no-progress 'extra-platforms==13.6.0'
+      - run: uvx --no-progress 'extra-platforms==13.7.0'

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -235,7 +235,7 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           COMMIT_SHA: ${{ github.sha }}
         run: >
-          npx --yes wrangler@4.126.0 pages deploy ./docs/_build
+          npx --yes wrangler@4.127.1 pages deploy ./docs/_build
           --project-name "$PROJECT_NAME"
           --branch "$REF_NAME"
           --commit-hash "$COMMIT_SHA"


### PR DESCRIPTION
## 🆙 Updated packages

Resolved with [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown `1 week`: releases after `2026-08-31` are held back.

| Package | Change | Released |
| :-- | :-- | :-- |
| [click-extra](https://pypi.org/project/click-extra/) | `8.9.1` → `9.0.0` | 2026-08-29 (a week ago) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.6.0` → `13.7.0` | 2026-08-28 (a week ago) |
| [wrangler](https://www.npmjs.com/package/wrangler) | `4.126.0` → `4.127.1` | 2026-08-28 (a week ago) |

### Release notes

<details>
<summary><code>click-extra</code></summary>

#### [`v9.0.0`](https://github.com/kdeldycke/click-extra/releases/tag/v9.0.0)

> [!NOTE]
> `9.0.0` is available on [🐍 PyPI](https://pypi.org/project/click-extra/9.0.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/click-extra/releases/tag/v9.0.0).

- **Breaking:** Raise the Click floor from `8.3.1` to `8.4.1`, dropping the compatibility shims the `8.3.x` releases needed.
- **Breaking:** Rename every camel-cased spinner preset to kebab case, so `boxBounce` is now `box-bounce`.
- **Breaking:** Rename the `solarized_dark` theme to `solarized-dark`.
- **Breaking:** Remove the `timeTravel` spinner preset, which is `SPINNERS["clock"]` with `reverse=True`.
- **Breaking:** `--man` now typesets the manual and pages it, the way `man` does, instead of printing roff to stdout; the source moved to `--help-format man`.
- **Breaking:** Remove `click-extra wrap --carapace` in favor of `wrap --help-format carapace`, one option carrying every rendering.
- **Breaking:** Rename the `click_extra.man_page` module to `click_extra.command_doc`, after the model it is built around rather than one of the four formats it renders.
- **Breaking:** Rename `ManPage` to `CommandDoc`, `ManOptionItem` to `DocOptionItem`, `ManOptionGroup` to `DocOptionGroup` and `extract_manpage()` to `extract_command_doc()`.
- **Breaking:** Remove every deprecated alias scheduled for removal in `9.0.0`: the `click_extra.test_plan` module, the root-level test-plan and config-schema names, and the invocation and pre-baking helpers' old homes.
- **Breaking:** `ConfigOption.search_and_read_file()` yields `(location, content, media_type)` triples instead of `(location, content)` pairs.
- **Breaking:** `LazyGroup.lazy_subcommands` holds `LazySubcommand` instances instead of import-path strings; the constructor still accepts either.
- **Deprecated:** Rename the `color_envvars` and `nocolor_theme` constants to `COLOR_ENVVARS` and `NOCOLOR_THEME`, following the uppercase convention; the old names resolve until `10.0.0`.

... [Full release notes](https://github.com/kdeldycke/click-extra/releases/tag/v9.0.0)

</details>

<details>
<summary><code>extra-platforms</code></summary>

#### [`v13.7.0`](https://github.com/kdeldycke/extra-platforms/releases/tag/v13.7.0)

> [!NOTE]
> `13.7.0` is available on [🐍 PyPI](https://pypi.org/project/extra-platforms/13.7.0/) and [🐙 GitHub](https://redirect.github.com/kdeldycke/extra-platforms/releases/tag/v13.7.0).

- Identify a Linux distribution through `systemd-hostnamed` when neither `/etc/os-release` nor `/usr/lib/os-release` is readable.
- Add agent detection for OpenAI Codex, GitHub Copilot CLI, Crush, Gemini CLI and Pi: `CODEX`, `COPILOT_CLI`, `CRUSH`, `GEMINI_CLI` and `PI`.
- Report an unrecognized agent at `WARNING` level when the generic `AI_AGENT` variable is set, as `LLM` already did.
- Drop the Codecov integration and its readme badge. Coverage is now gated by a local `[tool.coverage] report.fail_under` floor.
- Sync CI workflows with repomatic `7.14.0`; no functional changes to the package.
- Document the `platform_info` module on the platforms page, covering `os_release_id()`, `linux_info()`, `macos_info()` and `windows_info()`.
- Collect the codebase's future-work notes as `todo` admonitions, surfaced on the documentation's todo-list page.

**Full changelog**: [`v13.6.0...v13.7.0`](https://redirect.github.com/kdeldycke/extra-platforms/compare/v13.6.0...v13.7.0)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown window.

| Package | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [wrangler](https://www.npmjs.com/package/wrangler) | `4.127.1` | `4.129.0` | 2026-09-03 (4 days ago) | 2026-09-10 (in 3 days) |
| [click-extra](https://pypi.org/project/click-extra/) | `9.0.0` | `9.1.0` | 2026-09-03 (4 days ago) | 2026-09-10 (in 3 days) |
| [extra-platforms](https://pypi.org/project/extra-platforms/) | `13.7.0` | `13.7.1` | 2026-09-03 (4 days ago) | 2026-09-10 (in 3 days) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age)
- [`workflow-pins.sync`](https://repomatic.net/configuration#workflow-pins-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-workflow-pins`](https://repomatic.net/workflows#sync-workflow-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`f92b43be`](https://github.com/kdeldycke/repomatic/commit/f92b43bec33512c808776a8d592fbec3cd6de7b0)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/repomatic/blob/f92b43bec33512c808776a8d592fbec3cd6de7b0/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/repomatic/blob/f92b43bec33512c808776a8d592fbec3cd6de7b0/.github/workflows/autofix.yaml)
- **Run**: [#5494.1](https://github.com/kdeldycke/repomatic/actions/runs/34108658338)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.15.0.dev0`
