### PR TITLE
Sync tool versions

### DIFF
--- a/repomatic/tooling/tool_registry.py
+++ b/repomatic/tooling/tool_registry.py
@@ -1043,27 +1043,27 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "fb1238183c5dcfe9bb48772922c2ab62fa54158bfdc78352fa2851f41a71fa5a",
+        ): "b1e422c4cf5de788553f612b3952deadd6cb7669b35659197af14c4b1f763fab",
         (
             LINUX,
             X86_64,
-        ): "511592536991d4b07179d063b93ff0c092ccedba556a4b1ea70d12d46ea0785a",
+        ): "629a72d30e5b625b70723a651c510c0c2d4adc7c9b7334a690afe848ba4426ce",
         (
             MACOS,
             AARCH64,
-        ): "828bc29680765b656b6a354de01d9a7f9f5111e6af99b04cefe06d09c6d2dbda",
+        ): "7a067b00fdf8eeefb7f5f5f247b7dac1bb23adfeaea380a91293353b8e2eba2b",
         (
             MACOS,
             X86_64,
-        ): "3d87fe407532d708650be535573b159293e5c0176b51f8065eb45cc6e6861f48",
+        ): "74f6d1845e5c1a47ebafd42ba4a90ed174b4bb7a669d70acc1fd925894dbb168",
         (
             WINDOWS,
             AARCH64,
-        ): "58707afd02cc8522324e8f83906f44c9a78ceb4953c01e86def94bcd47fed0f9",
+        ): "e7db8b25ed9ddc602d0f0809643a0f1006ae10e67229d5e5de2926085c858b2c",
         (
             WINDOWS,
             X86_64,
-        ): "65125b8689718242c5e86aef43a9099e3313bec2c3fecb7a1bade02018b85acb",
+        ): "8bdf679275458a444f7befb8dacc38001625645cc498facf3cc114d77239f1cd",
     },
     "gh": {
         (
@@ -1183,45 +1183,45 @@ CHECKSUMS: dict[str, dict[PlatformKey, str]] = {
         (
             LINUX,
             AARCH64,
-        ): "32d92acaa5cd8abb29fc49dac123dc412442d5713967819d8af2c29f1b3857c7",
+        ): "8029959a945b5c6f2bc92ce53fca5cf0384c811cc0884b25b196a093a005657a",
         (
             LINUX,
             X86_64,
-        ): "fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1",
+        ): "fe42021c7272ef2d67ea36cbc3031683c625d0badec733ef3a57b567246a0b66",
         (
             MACOS,
             AARCH64,
-        ): "9680526be4a66ea1ffe988ed08af58e1400fe1e4f4aef5bd88b20bb9b3da33f8",
+        ): "4710ba8074a74334069719d5b82f8cb97532e5623bfe43ef7cdb3442101b9cb2",
         (
             MACOS,
             X86_64,
-        ): "6feedafc72915794163114f512348e2437d080d0047ef8b8fa2ec63b575f12af",
+        ): "74255a8087d74a79f5c1307db807e7efa8f062c429e3a05c075550392e0dcfa1",
         (
             WINDOWS,
             X86_64,
-        ): "60cd368533d0ad73fa86d93d5bbf95ef40587245ce684ed138c1b31557b5fe97",
+        ): "6738a3e155fbfec3bedc70962f9cd1610197587a43b5d7100f405239d8e11375",
     },
     "typos": {
         (
             LINUX,
             AARCH64,
-        ): "85c8b87b22a0fb1da130cd4d495e0beba7f1225eb580933184509e146ec4c509",
+        ): "a520651f52199efc91a27aa2b82362e93d50e7d96386d3d48b28c2ad06b9ae4e",
         (
             LINUX,
             X86_64,
-        ): "48bd2d58e02ce713b8c0f1aa239e68ee4f7d8c551013135806e6aed3938d9e10",
+        ): "a1497c9626ba0bab731b3e37c12ac9051bbfa2a253463d4d574c28f190b5497b",
         (
             MACOS,
             AARCH64,
-        ): "8c0e7bd40b2b60c0b0cfe9f74dd814b4d4385c956ce86860f7da9e62d91fdc73",
+        ): "3c9e3cdc20fbed3812c1f2060650398e88af0c0a251bbe069398752dd71513ed",
         (
             MACOS,
             X86_64,
-        ): "4cecbf653a9fc45f023abf57f4e2e2f6b138c2d2387b09289beacdd3f0ea7bfd",
+        ): "ab88faa54ab9ceac55c6fc2a9841ceab8ef883ed46522dbcbde2ec7a110350b0",
         (
             WINDOWS,
             X86_64,
-        ): "06d3a1b71c282e021671070696a72696d5c60ea485b47dc4f8f1fbcf90144d02",
+        ): "a48abe229e6fd48729ee891b2c410c41bfa9dc15ca77815e723c4b66c311c53c",
     },
 }
 """Tool name to platform-keyed SHA-256 hex digest mapping.
@@ -1234,14 +1234,14 @@ the registry, and so `VERSIONS` can anchor the offline staleness test.
 
 VERSIONS: dict[str, str] = {
     "actionlint": "1.7.12",
-    "biome": "2.5.10",
+    "biome": "2.5.11",
     "gh": "2.98.0",
     "gitleaks": "8.30.1",
     "labelmaker": "0.6.4",
     "lychee": "0.24.2",
     "oxipng": "10.2.0",
-    "shfmt": "3.13.1",
-    "typos": "1.49.0",
+    "shfmt": "3.14.0",
+    "typos": "1.50.0",
 }
 """Tool name to the version each checksum set was computed for.
 
@@ -1361,7 +1361,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         ),
         default_paths="json_files",
         display_name="Biome",
-        version="2.5.10",
+        version="2.5.11",
         source_url="https://github.com/biomejs/biome",
         tag_pattern=r"^@biomejs/biome@(?P<version>.+)$",
         config_docs_url="https://biomejs.dev/reference/configuration/",
@@ -1855,7 +1855,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "pyproject-fmt": ToolSpec(
         name="pyproject-fmt",
         default_paths="pyproject_files",
-        version="2.28.1",
+        version="2.28.2",
         source_url="https://github.com/tox-dev/pyproject-fmt",
         config_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
         cli_docs_url="https://pyproject-fmt.readthedocs.io/en/latest/",
@@ -1884,7 +1884,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "ruff": ToolSpec(
         name="ruff",
         display_name="Ruff",
-        version="0.16.4",
+        version="0.16.5",
         source_url="https://github.com/astral-sh/ruff",
         config_docs_url="https://docs.astral.sh/ruff/configuration/",
         cli_docs_url="https://docs.astral.sh/ruff/configuration/#command-line-interface",
@@ -1913,7 +1913,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "shfmt": ToolSpec(
         name="shfmt",
         default_paths="shfmt_files",
-        version="3.13.1",
+        version="3.14.0",
         source_url="https://github.com/mvdan/sh",
         config_docs_url="https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd",
         cli_docs_url="https://github.com/mvdan/sh#shfmt",
@@ -1958,7 +1958,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     ),
     "typos": ToolSpec(
         name="typos",
-        version="1.49.0",
+        version="1.50.0",
         source_url="https://github.com/crate-ci/typos",
         config_docs_url="https://github.com/crate-ci/typos/blob/master/docs/reference.md",
         cli_docs_url="https://github.com/crate-ci/typos/blob/master/docs/reference.md",
@@ -2059,7 +2059,7 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "zizmor": ToolSpec(
         name="zizmor",
         default_args=(".",),
-        version="1.29.0",
+        version="1.30.0",
         source_url="https://github.com/zizmorcore/zizmor",
         config_docs_url="https://docs.zizmor.sh/configuration/",
         cli_docs_url="https://docs.zizmor.sh/usage/",


### PR DESCRIPTION
## 🆙 Updated tools

Resolved with [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown `1 week`: releases after `2026-08-31` are held back.

| Tool | Change | Released |
| :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.10` → `2.5.11` | 2026-08-27 (a week ago) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.28.1` → `2.28.2` | 2026-08-28 (a week ago) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.4` → `0.16.5` | 2026-08-27 (a week ago) |
| [shfmt](https://github.com/mvdan/sh) | `3.13.1` → `3.14.0` | 2026-08-28 (a week ago) |
| [typos](https://github.com/crate-ci/typos) | `1.49.0` → `1.50.0` | 2026-08-28 (a week ago) |
| [zizmor](https://github.com/zizmorcore/zizmor) | `1.29.0` → `1.30.0` | 2026-08-30 (a week ago) |

### Release notes

<details>
<summary><code>biome</code></summary>

#### [`@biomejs/biome@2.5.11`](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.11)

##### 2.5.11

###### Patch Changes

- [#​11499](https://redirect.github.com/biomejs/biome/pull/11499) [`9743d0c`](https://redirect.github.com/biomejs/biome/commit/9743d0ceae807757300e5b0ec66266125bc664c1) Thanks [@​scs0209](https://redirect.github.com/scs0209)! - Fixed [#​11496](https://redirect.github.com/biomejs/biome/issues/11496): [`useValidAnchor`](https://biomejs.dev/linter/rules/use-valid-anchor/) now treats Astro JSX shorthand attributes like `<a {href}>` as a valid `href`.

- [#​11437](https://redirect.github.com/biomejs/biome/pull/11437) [`88f805e`](https://redirect.github.com/biomejs/biome/commit/88f805e19b67ab4c876e4fc4a8b4018bd03df20b) Thanks [@​Princesseuh](https://redirect.github.com/Princesseuh)! - Fixed [#​9944](https://redirect.github.com/biomejs/biome/issues/9944): adjacent elements inside an Astro expression now parse as an implicit fragment instead of raising an error.
  
  ```astro
  {options.map(() =>
    <div />
    <div />
  )}
  ```

- [#​11437](https://redirect.github.com/biomejs/biome/pull/11437) [`88f805e`](https://redirect.github.com/biomejs/biome/commit/88f805e19b67ab4c876e4fc4a8b4018bd03df20b) Thanks [@​Princesseuh](https://redirect.github.com/Princesseuh)! - Fixed Astro templates rejecting unclosed HTML void elements, such as `{cond && <br>}`.

- [#​11507](https://redirect.github.com/biomejs/biome/pull/11507) [`e2fc036`](https://redirect.github.com/biomejs/biome/commit/e2fc03669886732ac9c768aa00f3ffae46241848) Thanks [@​dyc3](https://redirect.github.com/dyc3)! - Fixed [#​11157](https://redirect.github.com/biomejs/biome/issues/11157): [`noUnusedVariables`](https://biomejs.dev/linter/rules/no-unused-variables/) no longer reports Vue `<script setup>` bindings used by CSS `v-bind()` as unused.

... [Full release notes](https://github.com/biomejs/biome/releases/tag/@biomejs/biome@2.5.11)

</details>

<details>
<summary><code>pyproject-fmt</code></summary>

#### [`v2.28.2`](https://github.com/tox-dev/pyproject-fmt/releases/tag/v2.28.2)

<!-- Release notes generated using configuration in .github/release.yaml at v2.28.2 -->

**Full Changelog**: https://redirect.github.com/tox-dev/pyproject-fmt/compare/v2.28.1...v2.28.2

</details>

<details>
<summary><code>ruff</code></summary>

#### [`0.16.5`](https://github.com/astral-sh/ruff/releases/tag/0.16.5)

##### Release Notes

Released on 2026-08-27.

###### Preview features

- Allow rules without codes ([#​28049](https://redirect.github.com/astral-sh/ruff/pull/28049))
- Introduce category selectors ([#​27666](https://redirect.github.com/astral-sh/ruff/pull/27666))
- Update preview default rules and categories ([#​27877](https://redirect.github.com/astral-sh/ruff/pull/27877))

###### Bug fixes

- \[`flake8-async`\] Detect blocking generic HTTP requests (`ASYNC210`) ([#​28024](https://redirect.github.com/astral-sh/ruff/pull/28024))
- \[`flake8-datetimez`\] Allow timezone-safe `strptime` chains (`DTZ007`) ([#​28023](https://redirect.github.com/astral-sh/ruff/pull/28023))
- \[`flake8-simplify`\] Respect side effects in `lambda` defaults (`SIM401`) ([#​28000](https://redirect.github.com/astral-sh/ruff/pull/28000))

###### Server

- Fix duplicated "of" in `ClientOptions` doc comment ([#​27978](https://redirect.github.com/astral-sh/ruff/pull/27978))

###### Documentation

- Document rule acceptance guidelines ([#​27910](https://redirect.github.com/astral-sh/ruff/pull/27910))
- Document the new category selectors ([#​27906](https://redirect.github.com/astral-sh/ruff/pull/27906))

###### Contributors

- [@​AlexWaygood](https://redirect.github.com/AlexWaygood)
- [@​sharkdp](https://redirect.github.com/sharkdp)
- [@​jelle-openai](https://redirect.github.com/jelle-openai)
- [@​charliermarsh](https://redirect.github.com/charliermarsh)
- [@​ntBre](https://redirect.github.com/ntBre)
- [@​aarushkandukoori](https://redirect.github.com/aarushkandukoori)

##### Install ruff 0.16.5

###### Install prebuilt binaries via shell script

```sh
curl --proto '=https' --tlsv1.2 -LsSf https://releases.astral.sh/github/ruff/releases/download/0.16.5/ruff-installer.sh | sh
```

###### Install prebuilt binaries via powershell script

```sh
powershell -ExecutionPolicy Bypass -c "irm https://releases.astral.sh/github/ruff/releases/download/0.16.5/ruff-installer.ps1 | iex"
```

... [Full release notes](https://github.com/astral-sh/ruff/releases/tag/0.16.5)

</details>

<details>
<summary><code>shfmt</code></summary>

#### [`v3.14.0`](https://github.com/mvdan/sh/releases/tag/v3.14.0)

This release drops support for Go 1.25 and includes many enhancements, particularly in the interpreter, which implements more shell features and fixes many divergences from Bash.

- **cmd/shfmt**
  - Add `--detect` to find shell files by executable bit or shebang - #​944
- **syntax**
  - Add `Preorder`, an iterator over all nodes, complementing `Walk`
  - Add `encoding.TextUnmarshaler` implementations for each operator type
  - Support `${ foo;}` and `${|foo;}` inside double quotes - #​1368
  - Support array elements in `{varname}` redirects, like `exec {fds[3]}>&-` - #​719
  - Backslashes inside backquotes within double quotes escape double quotes - #​1083
  - Allow pound signs in associative array keys like `${args[cmd,#]}` - #​1285
  - Don't treat `#` as the start of a comment inside `[[ ]]` tests - #​1326
  - Don't join `then` or `do` with a semicolon when heredocs are pending - #​1047
  - Print a space after `!` in arithmetic expressions, avoiding history expansion - #​987
  - Space nested closing parentheses like the opening ones - #​876
  - Make `SplitBraces` reject malformed sequences and skip backslash escapes - #​1330
  - Zsh: support the `${=name}`, `${~name}`, and `${^name}` prefixes - #​1238
  - Zsh: support the `;|` case terminator and leading parentheses for globs - #​1293, #​1279
  - Zsh: parse subscript flag arguments as patterns, and allow `[` globs in arrays - #​1278, #​1322
- **syntax/typedjson**
  - Encode operators as their syntax form, such as `">>"`, rather than integers - #​1321
  - Return errors rather than panicking on malformed input
- **interp**
  - Add `BashOpts` to set Bash options like `shopt` - #​962
  - Add `AccessHandler` to control file access checks, used by `-r` and `cd` - #​1318
  - Add `HandlerContext.LastExitStatus`, and provide a `HandlerContext` to stat handlers
  - Implement the `help` and `times` builtins, as well as `$-` - #​1398
  - Implement the `;&` and `;;&` case terminators - #​1391

... [Full release notes](https://github.com/mvdan/sh/releases/tag/v3.14.0)

</details>

<details>
<summary><code>typos</code></summary>

#### [`v1.49.1`](https://github.com/crate-ci/typos/releases/tag/v1.49.1)

##### [1.49.1] - 2026-08-27

###### Fixes

- Don't correct the brand name `HashiCorp`

#### [`v1.50.0`](https://github.com/crate-ci/typos/releases/tag/v1.50.0)

##### [1.50.0] - 2026-08-28

###### Features

- Updated the dictionary with the [August 2026](https://redirect.github.com/crate-ci/typos/issues/1587) changes

</details>

<details>
<summary><code>zizmor</code></summary>

#### [`v1.30.0`](https://github.com/zizmorcore/zizmor/releases/tag/v1.30.0)

[Sponsorship is appreciated!](https://redirect.github.com/sponsors/woodruffw/)

##### New Features 🌈[🔗](https://docs.zizmor.sh/release-notes/#new-features)

- New audit: [self-repository](https://docs.zizmor.sh/audits/#self-repository) detects usages of the old "workspace-relative" form for local reusable workflows and actions and recommends the new "self-repository" form instead ([#​2271](https://redirect.github.com/zizmorcore/zizmor/issues/2271))
Enhancements 🌱[🔗](https://docs.zizmor.sh/release-notes/#enhancements)

- The [impostor-commit](https://docs.zizmor.sh/audits/#impostor-commit) audit now supports pre-commit config inputs ([#​2256](https://redirect.github.com/zizmorcore/zizmor/issues/2256))

- The [forbidden-uses](https://docs.zizmor.sh/audits/#forbidden-uses) audit now supports pre-commit config inputs ([#​2263](https://redirect.github.com/zizmorcore/zizmor/issues/2263))

- The [adhoc-packages](https://docs.zizmor.sh/audits/#adhoc-packages) audit now detects more ad-hoc package management patterns, including bundle add and yarn add

    Many thanks to [@​connorshea](https://redirect.github.com/connorshea) for proposing and implementing this enhancement!

- The [archived-uses](https://docs.zizmor.sh/audits/#archived-uses) audit now supports pre-commit config inputs ([#​2272](https://redirect.github.com/zizmorcore/zizmor/issues/2272))

- The [ref-confusion](https://docs.zizmor.sh/audits/#ref-confusion) audit now supports pre-commit config inputs ([#​2274](https://redirect.github.com/zizmorcore/zizmor/issues/2274))

- The [cache-poisoning](https://docs.zizmor.sh/audits/#cache-poisoning) audit now produces more detailed and more precise diagnostics ([#​2330](https://redirect.github.com/zizmorcore/zizmor/issues/2330))

- The [cache-poisoning](https://docs.zizmor.sh/audits/#cache-poisoning) audit now handles and exposes auto-fixes in a more general manner ([#​2332](https://redirect.github.com/zizmorcore/zizmor/issues/2332))

... [Full release notes](https://github.com/zizmorcore/zizmor/releases/tag/v1.30.0)

</details>

## ⏸️ Held back by cooldown

Newer releases already published but withheld because they are still inside the [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age) cooldown window.

| Tool | Locked | Available | Released | Eligible |
| :-- | :-- | :-- | :-- | :-- |
| [biome](https://github.com/biomejs/biome) | `2.5.11` | `2.5.12` | 2026-09-03 (4 days ago) | 2026-09-10 (in 3 days) |
| [gh](https://github.com/cli/cli) | `2.98.0` | `2.100.0` | 2026-09-03 (4 days ago) | 2026-09-10 (in 3 days) |
| [nuitka](https://github.com/Nuitka/Nuitka) | `4.2` | `4.2.1` | 2026-09-05 (2 days ago) | 2026-09-12 (in 5 days) |
| [oxipng](https://github.com/shssoichiro/oxipng) | `10.2.0` | `10.2.1` | 2026-09-02 (5 days ago) | 2026-09-09 (in 2 days) |
| [pyproject-fmt](https://github.com/tox-dev/pyproject-fmt) | `2.28.2` | `2.29.3` | 2026-09-01 (6 days ago) | 2026-09-08 (in a day) |
| [ruff](https://github.com/astral-sh/ruff) | `0.16.5` | `0.16.6` | 2026-09-03 (4 days ago) | 2026-09-10 (in 3 days) |
| [shfmt](https://github.com/mvdan/sh) | `3.14.0` | `3.14.1` | 2026-09-06 (a day ago) | 2026-09-13 (in 6 days) |
| [typos](https://github.com/crate-ci/typos) | `1.50.0` | `1.50.1` | 2026-09-01 (6 days ago) | 2026-09-08 (in a day) |

## ⚙️ Configuration

Relevant [`[tool.repomatic]`](https://repomatic.net/configuration) options:

- [`minimum-release-age`](https://repomatic.net/configuration#minimum-release-age)
- [`tool-versions.sync`](https://repomatic.net/configuration#tool-versions-sync)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/repomatic/actions/workflows/self-maintenance.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-tool-versions`](https://repomatic.net/workflows#sync-tool-versions-sync-tool-versions)
- **Trigger**: `schedule`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`f92b43be`](https://github.com/kdeldycke/repomatic/commit/f92b43bec33512c808776a8d592fbec3cd6de7b0)
- **Job**: [`sync-tool-versions`](https://github.com/kdeldycke/repomatic/blob/f92b43bec33512c808776a8d592fbec3cd6de7b0/.github/workflows/self-maintenance.yaml)
- **Workflow**: [`self-maintenance.yaml`](https://github.com/kdeldycke/repomatic/blob/f92b43bec33512c808776a8d592fbec3cd6de7b0/.github/workflows/self-maintenance.yaml)
- **Run**: [#32.1](https://github.com/kdeldycke/repomatic/actions/runs/34112962335)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.15.0.dev0`
